### PR TITLE
Add image tile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository will contain a Python implementation of a 4x4 sliding tile puzzl
 ## Project Roadmap
 
 1. **Setup (Completed)**: Initial project structure created with core game logic and a basic `tkinter` GUI.
-2. **Image Handling**: Implement image upload support and a function to split the image into 4x4 tiles (15 tiles plus one empty slot).
-3. **Game Board Logic**: Represent the board as a 2D array and implement mechanics to shuffle tiles and determine valid moves (left, right, up, down from the empty space).
+2. **Image Handling (Completed)**: Implemented uploading an image and splitting it into tiles used in the GUI.
+3. **Game Board Logic (Completed)**: Board is represented as a 2D array with shuffling and move validation.
 4. **User Interaction**: Create a basic GUI that displays the tiles, allows tile movement via mouse clicks, and checks for a winning configuration after each move.
 5. **Win State & Reset**: Display a win screen or message when the player solves the puzzle, then provide an option to upload a new image and start over.
 6. **Enhancements**: Consider optional features such as move counters, timers, or a leaderboard.

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,7 +1,9 @@
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import filedialog, messagebox
+from PIL import ImageTk
 
 from .game import SlidingPuzzle
+from .image_utils import split_image_to_tiles
 
 
 def main() -> None:
@@ -11,14 +13,34 @@ def main() -> None:
     root = tk.Tk()
     root.title("Sliding Tile Puzzle")
 
+    # Ask user to select an image to use for the puzzle tiles
+    path = filedialog.askopenfilename(
+        title="Select an image",
+        filetypes=[("Image files", "*.png *.jpg *.jpeg *.gif")],
+    )
+    if not path:
+        return
+
+    # Load and split the selected image
+    tiles = split_image_to_tiles(path, puzzle.size)
+    photo_tiles = {
+        r * puzzle.size + c + 1: ImageTk.PhotoImage(tiles[r][c])
+        for r in range(puzzle.size)
+        for c in range(puzzle.size)
+    }
+
     buttons = []
+    tile_w, tile_h = tiles[0][0].size
 
     def update_buttons():
         for r in range(puzzle.size):
             for c in range(puzzle.size):
                 value = puzzle.board[r][c]
                 btn = buttons[r][c]
-                btn.config(text=str(value) if value else "")
+                if value == 0:
+                    btn.config(image="", text="")
+                else:
+                    btn.config(image=photo_tiles[value], text="")
 
     def on_click(r: int, c: int):
         if puzzle.move(r, c):
@@ -32,10 +54,21 @@ def main() -> None:
         row = []
         for c in range(puzzle.size):
             value = puzzle.board[r][c]
-            text = str(value) if value else ""
-            btn = tk.Button(root, text=text, width=4, height=2,
-                            command=lambda r=r, c=c: on_click(r, c))
-            btn.grid(row=r, column=c, padx=2, pady=2)
+            if value == 0:
+                img = ""
+                txt = ""
+            else:
+                img = photo_tiles[value]
+                txt = ""
+            btn = tk.Button(
+                root,
+                image=img,
+                text=txt,
+                width=tile_w,
+                height=tile_h,
+                command=lambda r=r, c=c: on_click(r, c),
+            )
+            btn.grid(row=r, column=c, padx=1, pady=1)
             row.append(btn)
         buttons.append(row)
 

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -1,0 +1,24 @@
+from typing import List
+from PIL import Image
+
+def split_image_to_tiles(path: str, size: int = 4) -> List[List[Image.Image]]:
+    """Load an image and split it into ``size`` x ``size`` tiles.
+
+    The returned list includes ``size`` lists of ``Image`` objects. The bottom-right
+    tile corresponds to the empty slot and is included so indexes match tile
+    numbers in :class:`src.game.SlidingPuzzle`.
+    """
+    img = Image.open(path)
+    width, height = img.size
+    tile_w = width // size
+    tile_h = height // size
+    img = img.resize((tile_w * size, tile_h * size))
+
+    tiles: List[List[Image.Image]] = []
+    for r in range(size):
+        row = []
+        for c in range(size):
+            box = (c * tile_w, r * tile_h, (c + 1) * tile_w, (r + 1) * tile_h)
+            row.append(img.crop(box))
+        tiles.append(row)
+    return tiles

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,4 +1,8 @@
+import os
+import sys
 import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.game import SlidingPuzzle
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.image_utils import split_image_to_tiles
+
+def test_split_image_to_tiles(tmp_path: Path) -> None:
+    # Create a simple test image
+    img = Image.new("RGB", (80, 80), "blue")
+    path = tmp_path / "test.png"
+    img.save(path)
+
+    tiles = split_image_to_tiles(str(path))
+    assert len(tiles) == 4
+    for row in tiles:
+        assert len(row) == 4
+        for tile in row:
+            assert tile.size == (20, 20)


### PR DESCRIPTION
## Summary
- allow selecting an image for the puzzle board
- split uploaded images into tiles for the GUI
- add unit tests for image splitting
- make tests import the `src` package
- update roadmap for progress

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849f628da408329b602e83ceb7a85ce