### PR TITLE
Fix missing tiles by resizing window

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -14,7 +14,8 @@ def main() -> None:
 
     root = tk.Tk()
     root.title("Sliding Tile Puzzle")
-    window_size = puzzle.size * TILE_SIZE
+    # account for padding around each tile so the entire board fits
+    window_size = puzzle.size * (TILE_SIZE + 2)
     root.geometry(f"{window_size}x{window_size + 40}")
     root.resizable(False, False)
 


### PR DESCRIPTION
## Summary
- account for padding when setting the window size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b33c7925083298865302f4e5b059c